### PR TITLE
Remove metrics options from function

### DIFF
--- a/chart/stash-postgres/README.md
+++ b/chart/stash-postgres/README.md
@@ -61,19 +61,11 @@ The following table lists the configurable parameters of the `stash-postgres` ch
 | `docker.tag`      | Tag of the image that is used to backup/restore PostgreSQL database. This is usually same as the database version it can backup. | `11.2`           |
 | `backup.pgArgs`   | Optional arguments to pass to `pgdump` command  during bakcup process                                                            |                  |
 | `restore.pgArgs`  | Optional arguments to pass to `psql` command during restore process                                                              |                  |
-| `metrics.enabled` | Specifies whether to send Prometheus metrics                                                                                     | `true`           |
-| `metrics.labels`  | Optional comma separated labels to add to the Prometheus metrics                                                                 |                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 For example:
 
 ```console
-helm install --name stash-postgres-11.2 --set metrics.enabled=false appscode/stash-postgres
-```
-
-**Tips:** Use escape character (`\`) while providing multiple comma-separated labels for `metrics.labels`.
-
-```console
- helm install chart/stash-postgres --set metrics.labels="k1=v1\,k2=v2"
+helm install --name stash-postgres-11.2 --set docker.registry=my-registry appscode/stash-postgres
 ```

--- a/chart/stash-postgres/templates/postgres-backup-function.yaml
+++ b/chart/stash-postgres/templates/postgres-backup-function.yaml
@@ -35,11 +35,6 @@ spec:
   - --retention-dry-run=${RETENTION_DRY_RUN:=false}
   # output & metric information
   - --output-dir=${outputDir:=}
-  - --metrics-enabled={{ .Values.metrics.enabled }}
-  - --metrics-pushgateway-url=${PROMETHEUS_PUSHGATEWAY_URL:=}
-  {{- if .Values.metrics.labels }}
-  - --metrics-labels={{ .Values.metrics.labels | quote }}
-  {{- end }}
   volumeMounts:
   - name: ${secretVolume}
     mountPath: /etc/repository/secret

--- a/chart/stash-postgres/templates/postgres-restore-function.yaml
+++ b/chart/stash-postgres/templates/postgres-restore-function.yaml
@@ -27,11 +27,6 @@ spec:
   - --snapshot=${RESTORE_SNAPSHOTS:=}
   # output & metric information
   - --output-dir=${outputDir:=}
-  - --metrics-enabled={{ .Values.metrics.enabled }}
-  - --metrics-pushgateway-url=${PROMETHEUS_PUSHGATEWAY_URL:=}
-  {{- if .Values.metrics.labels }}
-  - --metrics-labels={{ .Values.metrics.labels | quote }}
-  {{- end }}
   volumeMounts:
   - name: ${secretVolume}
     mountPath: /etc/repository/secret

--- a/chart/stash-postgres/values.yaml
+++ b/chart/stash-postgres/values.yaml
@@ -13,8 +13,3 @@ backup:
   pgArgs: ""
 restore:
   pgArgs: ""
-
-# default values for prometheus metrics
-metrics:
-  enabled: true
-  labels: []

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -683,6 +683,7 @@ So, from the above output, we can see the table `company` that we had created in
 To cleanup the Kubernetes resources created by this tutorial, run:
 
 ```console
+kubectl delete backupconfiguration -n demo sample-postgres-backup
 kubectl delete restoresession -n demo sample-postgres-restore
 kubectl delete pg -n demo restored-postgres
 kubectl delete pg -n demo sample-postgres

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/client-go v11.0.0+incompatible
 	kmodules.xyz/client-go v0.0.0-20190808141354-bbb9e14f60ab
 	kmodules.xyz/custom-resources v0.0.0-20190808144301-114abf10dfe2
-	stash.appscode.dev/stash v0.9.0-rc.0
+	stash.appscode.dev/stash v0.9.0-rc.0.0.20190826131715-3be27ba2689e
 )
 
 replace (
@@ -17,7 +17,7 @@ replace (
 	k8s.io/api => k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed
 	k8s.io/apimachinery => github.com/kmodules/apimachinery v0.0.0-20190508045248-a52a97a7a2bf
-	k8s.io/apiserver => github.com/kmodules/apiserver v0.0.0-20190508082252-8397d761d4b5
+	k8s.io/apiserver => github.com/kmodules/apiserver v0.0.0-20190811223248-5a95b2df4348
 	k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20190314001948-2899ed30580f
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.0.0-20190314002645-c892ea32361a
 	k8s.io/component-base => k8s.io/component-base v0.0.0-20190314000054-4a91899592f4

--- a/go.sum
+++ b/go.sum
@@ -177,7 +177,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kmodules/apimachinery v0.0.0-20190508045248-a52a97a7a2bf h1:XUigLZjjxvtR+TD7mncq0wUOaaG2H/zslqM42crk0SY=
 github.com/kmodules/apimachinery v0.0.0-20190508045248-a52a97a7a2bf/go.mod h1:1nbDY1cBTGna53FTjqnehJWker1BB75r+ElWRqNcYo8=
-github.com/kmodules/apiserver v0.0.0-20190508082252-8397d761d4b5/go.mod h1:rMEImsX8dFD0jGmDQXq3zbWddcIU8vlcrMWPzpXEm9g=
+github.com/kmodules/apiserver v0.0.0-20190811223248-5a95b2df4348/go.mod h1:rMEImsX8dFD0jGmDQXq3zbWddcIU8vlcrMWPzpXEm9g=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -431,8 +431,8 @@ kmodules.xyz/client-go v0.0.0-20190808141354-bbb9e14f60ab h1:rnKcFaDLtqpdooase2B
 kmodules.xyz/client-go v0.0.0-20190808141354-bbb9e14f60ab/go.mod h1:1GI6h5D31op/2D+Hrn9DhXW6iUd5wsHBQRoLeY7fndM=
 kmodules.xyz/custom-resources v0.0.0-20190808144301-114abf10dfe2 h1:u0zEFCvAttk09O64UzY1DVXNke9uAANmf4vllnVquS8=
 kmodules.xyz/custom-resources v0.0.0-20190808144301-114abf10dfe2/go.mod h1:vlKyFcCXC+2Kfn3Fa5Z7RnBWyp4t46FSeEutNqpqMm8=
-kmodules.xyz/objectstore-api v0.0.0-20190808153322-733e8798e8de h1:Z/z3SSS+mvRGzLT5HXLazogjnOYIfbYTYWrKBsiLtp8=
-kmodules.xyz/objectstore-api v0.0.0-20190808153322-733e8798e8de/go.mod h1:Wx+Ffc7weI6zv7NQvq0GWXMGGQFn6LqVb0KcXQFwRFs=
+kmodules.xyz/objectstore-api v0.0.0-20190824212210-196174aa0fc0 h1:ELq3ybK3noQP9SyZx34QsnZgU2As9r8hPAGEnuIy7Co=
+kmodules.xyz/objectstore-api v0.0.0-20190824212210-196174aa0fc0/go.mod h1:vFvmrMvRlkcUANfU4Ko3dZR3HUhWMUQc1sEHcwufims=
 kmodules.xyz/offshoot-api v0.0.0-20190808152534-e3dc715f844b h1:VZUtg4L9Qm2C7PBwa4sp/SvHckKidZSpkA33GoB24SA=
 kmodules.xyz/offshoot-api v0.0.0-20190808152534-e3dc715f844b/go.mod h1:AzvHBjJvhFwUEiWrEKfdsgoqt5Ulio44Beo1vPoq7ww=
 kmodules.xyz/openshift v0.0.0-20190808144841-c8f9a927f1d1 h1:NmVj5+kPpUgoxRans2XZt5SXm9cVy8E3b4yHaeVzqak=
@@ -444,5 +444,5 @@ sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5
 sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
-stash.appscode.dev/stash v0.9.0-rc.0 h1:GhzBnqHYBgq+2bcuwsDK3nhq2PPEhGkBH0EFAXp2OmY=
-stash.appscode.dev/stash v0.9.0-rc.0/go.mod h1:/YjAPx/9E4ScxWea1mbJC6qx9TomhqS83AUy2LufVVk=
+stash.appscode.dev/stash v0.9.0-rc.0.0.20190826131715-3be27ba2689e h1:AYVMg2yTN7lxe7IThGH0fc4iaBS4H8eBjCcu7w0OLmo=
+stash.appscode.dev/stash v0.9.0-rc.0.0.20190826131715-3be27ba2689e/go.mod h1:6WrRpjkI1av7305B60BLRx+PZzwMAoiGmOd5ewYAAyw=

--- a/vendor/kmodules.xyz/objectstore-api/api/v1/helpers.go
+++ b/vendor/kmodules.xyz/objectstore-api/api/v1/helpers.go
@@ -1,40 +1,61 @@
 package v1
 
 import (
+	"net/url"
+
 	"github.com/pkg/errors"
 	core "k8s.io/api/core/v1"
 )
 
-func (s Backend) Container() (string, error) {
-	if s.S3 != nil {
-		return s.S3.Bucket, nil
-	} else if s.GCS != nil {
-		return s.GCS.Bucket, nil
-	} else if s.Azure != nil {
-		return s.Azure.Container, nil
-	} else if s.Local != nil {
-		return s.Local.MountPath, nil
-	} else if s.Swift != nil {
-		return s.Swift.Container, nil
+const (
+	ProviderLocal = "local"
+	ProviderS3    = "s3"
+	ProviderGCS   = "gcs"
+	ProviderAzure = "azure"
+	ProviderSwift = "swift"
+	ProviderB2    = "b2"
+	ProviderRest  = "rest"
+)
+
+// Container returns name of the bucket
+func (backend Backend) Container() (string, error) {
+	if backend.Local != nil {
+		return backend.Local.MountPath, nil
+	} else if backend.S3 != nil {
+		return backend.S3.Bucket, nil
+	} else if backend.GCS != nil {
+		return backend.GCS.Bucket, nil
+	} else if backend.Azure != nil {
+		return backend.Azure.Container, nil
+	} else if backend.Swift != nil {
+		return backend.Swift.Container, nil
+	} else if backend.Rest != nil {
+		u, err := url.Parse(backend.Rest.URL)
+		if err != nil {
+			return "", err
+		}
+		return u.Host, nil
+	}
+	return "", errors.New("failed to get container. Reason: Unknown backend type.")
+}
+
+// Location returns the location of backend (<provider>:<bucket name>)
+func (backend Backend) Location() (string, error) {
+	if backend.S3 != nil {
+		return "s3:" + backend.S3.Bucket, nil
+	} else if backend.GCS != nil {
+		return "gs:" + backend.GCS.Bucket, nil
+	} else if backend.Azure != nil {
+		return "azure:" + backend.Azure.Container, nil
+	} else if backend.Local != nil {
+		return "local:" + backend.Local.MountPath, nil
+	} else if backend.Swift != nil {
+		return "swift:" + backend.Swift.Container, nil
 	}
 	return "", errors.New("no storage provider is configured")
 }
 
-func (s Backend) Location() (string, error) {
-	if s.S3 != nil {
-		return "s3:" + s.S3.Bucket, nil
-	} else if s.GCS != nil {
-		return "gs:" + s.GCS.Bucket, nil
-	} else if s.Azure != nil {
-		return "azure:" + s.Azure.Container, nil
-	} else if s.Local != nil {
-		return "local:" + s.Local.MountPath, nil
-	} else if s.Swift != nil {
-		return "swift:" + s.Swift.Container, nil
-	}
-	return "", errors.New("no storage provider is configured")
-}
-
+// ToVolumeAndMount returns volumes and mounts for local backend
 func (l LocalSpec) ToVolumeAndMount(volName string) (core.Volume, core.VolumeMount) {
 	vol := core.Volume{
 		Name:         volName,
@@ -46,4 +67,69 @@ func (l LocalSpec) ToVolumeAndMount(volName string) (core.Volume, core.VolumeMou
 		SubPath:   l.SubPath,
 	}
 	return vol, mnt
+}
+
+// Prefix returns the prefix used in the backend
+func (backend Backend) Prefix() (string, error) {
+	if backend.Local != nil {
+		return "", nil
+	} else if backend.S3 != nil {
+		return backend.S3.Prefix, nil
+	} else if backend.GCS != nil {
+		return backend.GCS.Prefix, nil
+	} else if backend.Azure != nil {
+		return backend.Azure.Prefix, nil
+	} else if backend.Swift != nil {
+		return backend.Swift.Prefix, nil
+	} else if backend.Rest != nil {
+		u, err := url.Parse(backend.Rest.URL)
+		if err != nil {
+			return "", err
+		}
+		return u.Path, nil
+	}
+	return "", errors.New("failed to get prefix. Reason: Unknown backend type.")
+}
+
+// Provider returns the provider of the backend
+func (backend Backend) Provider() (string, error) {
+	if backend.Local != nil {
+		return ProviderLocal, nil
+	} else if backend.S3 != nil {
+		return ProviderS3, nil
+	} else if backend.GCS != nil {
+		return ProviderGCS, nil
+	} else if backend.Azure != nil {
+		return ProviderAzure, nil
+	} else if backend.Swift != nil {
+		return ProviderSwift, nil
+	} else if backend.B2 != nil {
+		return ProviderB2, nil
+	} else if backend.Rest != nil {
+		return ProviderRest, nil
+	}
+	return "", errors.New("unknown provider.")
+}
+
+// MaxConnections returns maximum parallel connection to use to connect with the backend
+// returns 0 if not specified
+func (backend Backend) MaxConnections() int {
+	if backend.GCS != nil {
+		return backend.GCS.MaxConnections
+	} else if backend.Azure != nil {
+		return backend.Azure.MaxConnections
+	} else if backend.B2 != nil {
+		return backend.B2.MaxConnections
+	}
+	return 0
+}
+
+// Endpoint returns endpoint of Restic rest server and S3/S3 compatible backend
+func (backend Backend) Endpoint() (string, bool) {
+	if backend.S3 != nil {
+		return backend.S3.Endpoint, true
+	} else if backend.Rest != nil {
+		return backend.Rest.URL, true
+	}
+	return "", false
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -317,7 +317,6 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 # k8s.io/apimachinery v0.0.0-20190508063446-a3da69d3723c => github.com/kmodules/apimachinery v0.0.0-20190508045248-a52a97a7a2bf
 k8s.io/apimachinery/pkg/apis/meta/v1
-k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/runtime/serializer
@@ -331,12 +330,13 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/intstr
-k8s.io/apimachinery/pkg/util/sets
+k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/naming
+k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
@@ -512,7 +512,7 @@ kmodules.xyz/custom-resources/client/clientset/versioned/typed/appcatalog/v1alph
 kmodules.xyz/custom-resources/apis/appcatalog/v1alpha1
 kmodules.xyz/custom-resources/client/clientset/versioned/scheme
 kmodules.xyz/custom-resources/apis/appcatalog
-# kmodules.xyz/objectstore-api v0.0.0-20190808153322-733e8798e8de
+# kmodules.xyz/objectstore-api v0.0.0-20190824212210-196174aa0fc0
 kmodules.xyz/objectstore-api/api/v1
 # kmodules.xyz/offshoot-api v0.0.0-20190808152534-e3dc715f844b
 kmodules.xyz/offshoot-api/api/v1
@@ -551,7 +551,7 @@ sigs.k8s.io/kustomize/pkg/expansion
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/stash v0.9.0-rc.0
+# stash.appscode.dev/stash v0.9.0-rc.0.0.20190826131715-3be27ba2689e
 stash.appscode.dev/stash/client/clientset/versioned/fake
 stash.appscode.dev/stash/apis
 stash.appscode.dev/stash/client/clientset/versioned/scheme

--- a/vendor/stash.appscode.dev/stash/apis/constants.go
+++ b/vendor/stash.appscode.dev/stash/apis/constants.go
@@ -56,4 +56,7 @@ const (
 	StatusSubresourceEnabled = "ENABLE_STATUS_SUBRESOURCE"
 
 	PushgatewayURL = "PROMETHEUS_PUSHGATEWAY_URL"
+
+	StashDefaultVolume    = "stash-volume"
+	StashDefaultMountPath = "/stash-data"
 )

--- a/vendor/stash.appscode.dev/stash/apis/stash/v1beta1/annotations.go
+++ b/vendor/stash.appscode.dev/stash/apis/stash/v1beta1/annotations.go
@@ -6,7 +6,6 @@ const (
 
 	KeyBackupBlueprint = StashKey + "/backup-blueprint"
 	KeyTargetPaths     = StashKey + "/target-paths"
-	KeyMountPath       = StashKey + "/mountpath"
 	KeyVolumeMounts    = StashKey + "/volume-mounts"
 
 	KeyLastAppliedRestoreSession      = StashKey + "/last-applied-restoresession"

--- a/vendor/stash.appscode.dev/stash/pkg/restic/commands.go
+++ b/vendor/stash.appscode.dev/stash/pkg/restic/commands.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/appscode/go/log"
 	"github.com/armon/circbuf"
+	storage "kmodules.xyz/objectstore-api/api/v1"
 	"stash.appscode.dev/stash/apis/stash/v1alpha1"
 )
 
@@ -286,11 +287,11 @@ func (w *ResticWrapper) appendMaxConnectionsFlag(args []interface{}) []interface
 	var maxConOption string
 	if w.config.MaxConnections > 0 {
 		switch w.config.Provider {
-		case ProviderGCS:
+		case storage.ProviderGCS:
 			maxConOption = fmt.Sprintf("gs.connections=%d", w.config.MaxConnections)
-		case ProviderAzure:
+		case storage.ProviderAzure:
 			maxConOption = fmt.Sprintf("azure.connections=%d", w.config.MaxConnections)
-		case ProviderB2:
+		case storage.ProviderB2:
 			maxConOption = fmt.Sprintf("b2.connections=%d", w.config.MaxConnections)
 		}
 	}

--- a/vendor/stash.appscode.dev/stash/pkg/restic/metrics.go
+++ b/vendor/stash.appscode.dev/stash/pkg/restic/metrics.go
@@ -8,7 +8,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	appcatalog_cs "kmodules.xyz/custom-resources/client/clientset/versioned"
+	"stash.appscode.dev/stash/apis"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
+	cs "stash.appscode.dev/stash/client/clientset/versioned"
 )
 
 // BackupMetrics defines prometheus metrics for backup setup and individual host backup
@@ -240,8 +245,11 @@ func newRestoreMetrics(labels prometheus.Labels) *RestoreMetrics {
 }
 
 // HandleBackupSetupMetrics generate and send Prometheus metrics for backup setup
-func HandleBackupSetupMetrics(metricOpt MetricsOptions, setupErr error) error {
-	labels := metricLabels(metricOpt.Labels)
+func HandleBackupSetupMetrics(config *rest.Config, backupConfig *api_v1beta1.BackupConfiguration, metricOpt MetricsOptions, setupErr error) error {
+	labels, err := backupMetricLabels(config, backupConfig, metricOpt.Labels)
+	if err != nil {
+		return err
+	}
 	metrics := newBackupSetupMetrics(labels)
 
 	if setupErr == nil {
@@ -260,14 +268,17 @@ func HandleBackupSetupMetrics(metricOpt MetricsOptions, setupErr error) error {
 }
 
 // HandleMetrics generate and send Prometheus metrics for backup process
-func (backupOutput *BackupOutput) HandleMetrics(metricOpt *MetricsOptions, backupErr error) error {
-
+func (backupOutput *BackupOutput) HandleMetrics(config *rest.Config, backupConfig *api_v1beta1.BackupConfiguration, metricOpt *MetricsOptions, backupErr error) error {
 	// create metric registry
 	registry := prometheus.NewRegistry()
 
+	labels, err := backupMetricLabels(config, backupConfig, metricOpt.Labels)
+	if err != nil {
+		return err
+	}
+
 	if backupOutput == nil {
 		if backupErr != nil {
-			labels := metricLabels(metricOpt.Labels)
 			metrics := newBackupMetrics(labels)
 			metrics.HostBackupMetrics.BackupSuccess.Set(0)
 			registry.MustRegister(metrics.HostBackupMetrics.BackupSuccess)
@@ -279,9 +290,10 @@ func (backupOutput *BackupOutput) HandleMetrics(metricOpt *MetricsOptions, backu
 	// create metrics for individual hosts
 	for _, hostStats := range backupOutput.HostBackupStats {
 		// add host name as label
-		metricOpt.Labels = append(metricOpt.Labels, fmt.Sprintf("Host=%s", hostStats.Hostname))
-		labels := metricLabels(metricOpt.Labels)
-		metrics := newBackupMetrics(labels)
+		hostLabel := map[string]string{
+			"hostname": hostStats.Hostname,
+		}
+		metrics := newBackupMetrics(upsertLabel(labels, hostLabel))
 
 		if backupErr == nil && hostStats.Error == "" {
 			// set metrics values from backupOutput
@@ -308,8 +320,13 @@ func (backupOutput *BackupOutput) HandleMetrics(metricOpt *MetricsOptions, backu
 	}
 
 	// crete repository metrics
-	repoMetrics := newRepositoryMetrics(metricLabels(metricOpt.Labels))
-	err := repoMetrics.setValues(backupOutput.RepositoryStats)
+	repoMetricLabels, err := repoMetricLabels(config, backupConfig, metricOpt.Labels)
+	if err != nil {
+		return err
+	}
+
+	repoMetrics := newRepositoryMetrics(repoMetricLabels)
+	err = repoMetrics.setValues(backupOutput.RepositoryStats)
 	if err != nil {
 		return err
 	}
@@ -325,13 +342,16 @@ func (backupOutput *BackupOutput) HandleMetrics(metricOpt *MetricsOptions, backu
 	return metricOpt.sendMetrics(registry, metricOpt.JobName)
 }
 
-func (restoreOutput *RestoreOutput) HandleMetrics(metricOpt *MetricsOptions, restoreErr error) error {
+func (restoreOutput *RestoreOutput) HandleMetrics(config *rest.Config, restoreSession *api_v1beta1.RestoreSession, metricOpt *MetricsOptions, restoreErr error) error {
 	// create metric registry
 	registry := prometheus.NewRegistry()
 
+	labels, err := restoreMetricLabels(config, restoreSession, metricOpt.Labels)
+	if err != nil {
+		return err
+	}
 	if restoreOutput == nil {
 		if restoreErr != nil {
-			labels := metricLabels(metricOpt.Labels)
 			metrics := newRestoreMetrics(labels)
 			metrics.RestoreSuccess.Set(0)
 			registry.MustRegister(metrics.RestoreSuccess)
@@ -343,9 +363,10 @@ func (restoreOutput *RestoreOutput) HandleMetrics(metricOpt *MetricsOptions, res
 	// create metrics for each host
 	for _, hostStats := range restoreOutput.HostRestoreStats {
 		// add host name as label
-		metricOpt.Labels = append(metricOpt.Labels, fmt.Sprintf("Host=%s", hostStats.Hostname))
-		labels := metricLabels(metricOpt.Labels)
-		metrics := newRestoreMetrics(labels)
+		hostLabel := map[string]string{
+			"hostname": hostStats.Hostname,
+		}
+		metrics := newRestoreMetrics(upsertLabel(labels, hostLabel))
 
 		if restoreErr == nil && hostStats.Error == "" {
 			duration, err := time.ParseDuration(hostStats.Duration)
@@ -457,13 +478,154 @@ func (metricOpt *MetricsOptions) sendMetrics(registry *prometheus.Registry, jobN
 	return nil
 }
 
-func metricLabels(labels []string) prometheus.Labels {
+func backupMetricLabels(clientConfig *rest.Config, backupConfig *api_v1beta1.BackupConfiguration, userProvidedLabels []string) (prometheus.Labels, error) {
 	promLabels := prometheus.Labels{}
-	for _, v := range labels {
+	for _, v := range userProvidedLabels {
 		parts := strings.Split(v, "=")
 		if len(parts) == 2 {
 			promLabels[parts[0]] = parts[1]
 		}
 	}
-	return promLabels
+	// insert target information as metrics label
+	if backupConfig != nil {
+		if backupConfig.Spec.Driver == api_v1beta1.VolumeSnapshotter {
+			promLabels["driver"] = string(api_v1beta1.VolumeSnapshotter)
+			// for VolumeSnapshot individual volumes is target
+			promLabels["kind"] = apis.KindPersistentVolumeClaim
+			// for VolumeSnapshot hostname label will have the respective PVC name
+		} else {
+			promLabels["driver"] = string(api_v1beta1.ResticSnapshotter)
+			// if target specified then add target info as label
+			if backupConfig.Spec.Target != nil {
+				switch backupConfig.Spec.Target.Ref.Kind {
+				case apis.KindAppBinding:
+					appKind, err := getAppKind(clientConfig, backupConfig.Spec.Target.Ref.Name, backupConfig.Namespace)
+					if err != nil {
+						return nil, err
+					}
+					promLabels["kind"] = appKind
+				default:
+					promLabels["kind"] = backupConfig.Spec.Target.Ref.Kind
+				}
+				promLabels["name"] = backupConfig.Spec.Target.Ref.Name
+			}
+		}
+		promLabels["namespace"] = backupConfig.Namespace
+		promLabels["repository"] = backupConfig.Spec.Repository.Name
+	}
+	return promLabels, nil
+}
+
+func repoMetricLabels(clientConfig *rest.Config, backupConfig *api_v1beta1.BackupConfiguration, userProvidedLabels []string) (prometheus.Labels, error) {
+	promLabels := prometheus.Labels{}
+	for _, v := range userProvidedLabels {
+		parts := strings.Split(v, "=")
+		if len(parts) == 2 {
+			promLabels[parts[0]] = parts[1]
+		}
+	}
+
+	// insert repository information as label
+	if backupConfig != nil && backupConfig.Spec.Target != nil {
+		stashClient, err := cs.NewForConfig(clientConfig)
+		if err != nil {
+			return nil, err
+		}
+		repository, err := stashClient.StashV1alpha1().Repositories(backupConfig.Namespace).Get(backupConfig.Spec.Repository.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		provider, err := repository.Spec.Backend.Provider()
+		if err != nil {
+			return nil, err
+		}
+		bucket, err := repository.Spec.Backend.Container()
+		if err != nil {
+			return nil, err
+		}
+		prefix, err := repository.Spec.Backend.Prefix()
+		if err != nil {
+			return nil, err
+		}
+
+		promLabels["name"] = repository.Name
+		promLabels["namespace"] = repository.Namespace
+		promLabels["backend"] = provider
+		if bucket != "" {
+			promLabels["bucket"] = bucket
+		}
+		if prefix != "" {
+			promLabels["prefix"] = prefix
+		}
+	}
+	return promLabels, nil
+}
+
+func restoreMetricLabels(clientConfig *rest.Config, restoreSession *api_v1beta1.RestoreSession, userProvidedLabels []string) (prometheus.Labels, error) {
+	promLabels := prometheus.Labels{}
+	for _, v := range userProvidedLabels {
+		parts := strings.Split(v, "=")
+		if len(parts) == 2 {
+			promLabels[parts[0]] = parts[1]
+		}
+	}
+	// insert target information as metrics label
+	if restoreSession != nil {
+		if restoreSession.Spec.Driver == api_v1beta1.VolumeSnapshotter {
+			promLabels["driver"] = string(api_v1beta1.VolumeSnapshotter)
+			// for VolumeSnapshot individual volumes is target
+			promLabels["kind"] = apis.KindPersistentVolumeClaim
+			// for VolumeSnapshot hostname label will have the respective PVC name
+		} else {
+			promLabels["driver"] = string(api_v1beta1.ResticSnapshotter)
+			// if target specified then add target info as label
+			if restoreSession.Spec.Target != nil {
+				switch restoreSession.Spec.Target.Ref.Kind {
+				case apis.KindAppBinding:
+					appKind, err := getAppKind(clientConfig, restoreSession.Spec.Target.Ref.Name, restoreSession.Namespace)
+					if err != nil {
+						return nil, err
+					}
+					promLabels["kind"] = appKind
+				default:
+					promLabels["kind"] = restoreSession.Spec.Target.Ref.Kind
+				}
+				promLabels["name"] = restoreSession.Spec.Target.Ref.Name
+			}
+		}
+		promLabels["namespace"] = restoreSession.Namespace
+		promLabels["repository"] = restoreSession.Spec.Repository.Name
+	}
+	return promLabels, nil
+}
+
+func upsertLabel(original, new map[string]string) map[string]string {
+	labels := make(map[string]string)
+	// copy old original labels
+	for k, v := range original {
+		labels[k] = v
+	}
+	// insert new labels
+	for k, v := range new {
+		labels[k] = v
+	}
+
+	return labels
+}
+
+func getAppKind(clientConfig *rest.Config, name, namespace string) (string, error) {
+	appClient, err := appcatalog_cs.NewForConfig(clientConfig)
+	if err != nil {
+		return "", err
+	}
+	appbinding, err := appClient.AppcatalogV1alpha1().AppBindings(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	// if app type is provided then use it
+	_, targetAppResource := appbinding.AppGroupResource()
+	if targetAppResource == "" {
+		return appbinding.Kind, nil
+	}
+	return targetAppResource, nil
 }

--- a/vendor/stash.appscode.dev/stash/pkg/restic/setup.go
+++ b/vendor/stash.appscode.dev/stash/pkg/restic/setup.go
@@ -6,17 +6,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+
+	storage "kmodules.xyz/objectstore-api/api/v1"
 )
 
 const (
-	ProviderLocal = "local"
-	ProviderS3    = "s3"
-	ProviderGCS   = "gcs"
-	ProviderAzure = "azure"
-	ProviderSwift = "swift"
-	ProviderB2    = "b2"
-	ProviderRest  = "rest"
-
 	RESTIC_REPOSITORY = "RESTIC_REPOSITORY"
 	RESTIC_PASSWORD   = "RESTIC_PASSWORD"
 	TMPDIR            = "TMPDIR"
@@ -99,14 +93,14 @@ func (w *ResticWrapper) setupEnv() error {
 
 	switch w.config.Provider {
 
-	case ProviderLocal:
+	case storage.ProviderLocal:
 		r := w.config.Path
 		if err := os.MkdirAll(r, 0755); err != nil {
 			return err
 		}
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 
-	case ProviderS3:
+	case storage.ProviderS3:
 		r := fmt.Sprintf("s3:%s/%s", w.config.Endpoint, filepath.Join(w.config.Bucket, w.config.Path))
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 
@@ -117,7 +111,7 @@ func (w *ResticWrapper) setupEnv() error {
 			w.sh.SetEnv(AWS_SECRET_ACCESS_KEY, string(v))
 		}
 
-	case ProviderGCS:
+	case storage.ProviderGCS:
 		r := fmt.Sprintf("gs:%s:/%s", w.config.Bucket, w.config.Path)
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 
@@ -130,7 +124,7 @@ func (w *ResticWrapper) setupEnv() error {
 			w.sh.SetEnv(GOOGLE_APPLICATION_CREDENTIALS, filepath.Join(w.config.SecretDir, GOOGLE_SERVICE_ACCOUNT_JSON_KEY))
 		}
 
-	case ProviderAzure:
+	case storage.ProviderAzure:
 		r := fmt.Sprintf("azure:%s:/%s", w.config.Bucket, w.config.Path)
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 
@@ -141,7 +135,7 @@ func (w *ResticWrapper) setupEnv() error {
 			w.sh.SetEnv(AZURE_ACCOUNT_KEY, string(v))
 		}
 
-	case ProviderSwift:
+	case storage.ProviderSwift:
 		r := fmt.Sprintf("swift:%s:/%s", w.config.Bucket, w.config.Path)
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 
@@ -240,7 +234,7 @@ func (w *ResticWrapper) setupEnv() error {
 			w.sh.SetEnv(OS_AUTH_TOKEN, string(v))
 		}
 
-	case ProviderB2:
+	case storage.ProviderB2:
 		r := fmt.Sprintf("b2:%s:/%s", w.config.Bucket, w.config.Path)
 		w.sh.SetEnv(RESTIC_REPOSITORY, r)
 
@@ -252,7 +246,7 @@ func (w *ResticWrapper) setupEnv() error {
 			w.sh.SetEnv(B2_ACCOUNT_KEY, string(v))
 		}
 
-	case ProviderRest:
+	case storage.ProviderRest:
 		u, err := url.Parse(w.config.URL)
 		if err != nil {
 			return err

--- a/vendor/stash.appscode.dev/stash/pkg/util/crds.go
+++ b/vendor/stash.appscode.dev/stash/pkg/util/crds.go
@@ -1,8 +1,11 @@
 package util
 
 import (
+	"fmt"
+
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"stash.appscode.dev/stash/apis"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 	cs "stash.appscode.dev/stash/client/clientset/versioned"
 	util_v1beta1 "stash.appscode.dev/stash/client/clientset/versioned/typed/stash/v1beta1/util"
@@ -69,6 +72,8 @@ func updateStatusFunction(image docker.Docker) *api_v1beta1.Function {
 				"--repository=${REPOSITORY_NAME:=}",
 				"--restore-session=${RESTORE_SESSION:=}",
 				"--output-dir=${outputDir:=}",
+				"--metrics-enabled=true",
+				fmt.Sprintf("--metrics-pushgateway-url=%s", PushgatewayURL()),
 				"--enable-status-subresource=${ENABLE_STATUS_SUBRESOURCE:=false}",
 			},
 		},
@@ -105,8 +110,6 @@ func pvcBackupFunction(image docker.Docker) *api_v1beta1.Function {
 				"--retention-prune=${RETENTION_PRUNE:=false}",
 				"--retention-dry-run=${RETENTION_DRY_RUN:=false}",
 				"--output-dir=${outputDir:=}",
-				"--metrics-enabled=true",
-				"--metrics-pushgateway-url=${PROMETHEUS_PUSHGATEWAY_URL:=}",
 			},
 			VolumeMounts: []core.VolumeMount{
 				{
@@ -144,8 +147,6 @@ func pvcRestoreFunction(image docker.Docker) *api_v1beta1.Function {
 				"--restore-paths=${RESTORE_PATHS}",
 				"--snapshots=${RESTORE_SNAPSHOTS:=}",
 				"--output-dir=${outputDir:=}",
-				"--metrics-enabled=true",
-				"--metrics-pushgateway-url=${PROMETHEUS_PUSHGATEWAY_URL:=}",
 			},
 			VolumeMounts: []core.VolumeMount{
 				{
@@ -177,7 +178,7 @@ func pvcBackupTask() *api_v1beta1.Task {
 						},
 						{
 							Name:  "targetVolume",
-							Value: "target-volume",
+							Value: apis.StashDefaultVolume,
 						},
 						{
 							Name:  "secretVolume",
@@ -197,7 +198,7 @@ func pvcBackupTask() *api_v1beta1.Task {
 			},
 			Volumes: []core.Volume{
 				{
-					Name: "target-volume",
+					Name: apis.StashDefaultVolume,
 					VolumeSource: core.VolumeSource{
 						PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
 							ClaimName: "${TARGET_NAME}",
@@ -233,7 +234,7 @@ func pvcRestoreTask() *api_v1beta1.Task {
 						},
 						{
 							Name:  "targetVolume",
-							Value: "target-volume",
+							Value: apis.StashDefaultVolume,
 						},
 						{
 							Name:  "secretVolume",
@@ -253,7 +254,7 @@ func pvcRestoreTask() *api_v1beta1.Task {
 			},
 			Volumes: []core.Volume{
 				{
-					Name: "target-volume",
+					Name: apis.StashDefaultVolume,
 					VolumeSource: core.VolumeSource{
 						PersistentVolumeClaim: &core.PersistentVolumeClaimVolumeSource{
 							ClaimName: "${TARGET_NAME}",

--- a/vendor/stash.appscode.dev/stash/pkg/util/init_container.go
+++ b/vendor/stash.appscode.dev/stash/pkg/util/init_container.go
@@ -43,7 +43,7 @@ func NewRestoreInitContainer(rs *v1beta1_api.RestoreSession, repository *v1alpha
 			"--restore-session=" + rs.Name,
 			"--secret-dir=" + StashSecretMountDir,
 			fmt.Sprintf("--enable-cache=%v", !rs.Spec.TempDir.DisableCaching),
-			fmt.Sprintf("--max-connections=%v", GetMaxConnections(repository.Spec.Backend)),
+			fmt.Sprintf("--max-connections=%v", repository.Spec.Backend.MaxConnections()),
 			"--metrics-enabled=true",
 			"--pushgateway-url=" + PushgatewayURL(),
 			fmt.Sprintf("--enable-status-subresource=%v", apis.EnableStatusSubresource),

--- a/vendor/stash.appscode.dev/stash/pkg/util/job.go
+++ b/vendor/stash.appscode.dev/stash/pkg/util/job.go
@@ -209,7 +209,7 @@ func NewPVCRestorerJob(rs *api_v1beta1.RestoreSession, repository *api_v1alpha1.
 			"--restore-model=job",
 			"--secret-dir=" + StashSecretMountDir,
 			fmt.Sprintf("--enable-cache=%v", !rs.Spec.TempDir.DisableCaching),
-			fmt.Sprintf("--max-connections=%v", GetMaxConnections(repository.Spec.Backend)),
+			fmt.Sprintf("--max-connections=%v", repository.Spec.Backend.MaxConnections()),
 			"--metrics-enabled=true",
 			"--pushgateway-url=" + PushgatewayURL(),
 			fmt.Sprintf("--enable-status-subresource=%v", apis.EnableStatusSubresource),

--- a/vendor/stash.appscode.dev/stash/pkg/util/options.go
+++ b/vendor/stash.appscode.dev/stash/pkg/util/options.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	go_str "github.com/appscode/go/strings"
+	storage "kmodules.xyz/objectstore-api/api/v1"
 	api_v1alpha1 "stash.appscode.dev/stash/apis/stash/v1alpha1"
 	api "stash.appscode.dev/stash/apis/stash/v1beta1"
 	"stash.appscode.dev/stash/pkg/restic"
@@ -63,24 +64,35 @@ func RestoreOptionsForHost(hostname string, rules []api.Rule) restic.RestoreOpti
 }
 
 func SetupOptionsForRepository(repository api_v1alpha1.Repository, extraOpt ExtraOptions) (restic.SetupOptions, error) {
-	provider, err := GetProvider(repository.Spec.Backend)
+	provider, err := repository.Spec.Backend.Provider()
 	if err != nil {
 		return restic.SetupOptions{}, err
 	}
-	bucket, prefix, err := GetBucketAndPrefix(&repository.Spec.Backend)
+	bucket, err := repository.Spec.Backend.Container()
 	if err != nil {
 		return restic.SetupOptions{}, err
 	}
+	prefix, err := repository.Spec.Backend.Prefix()
+	if err != nil {
+		return restic.SetupOptions{}, err
+	}
+	var endpoint, restURL string
+	if provider == storage.ProviderRest {
+		restURL, _ = repository.Spec.Backend.Endpoint()
+	} else {
+		endpoint, _ = repository.Spec.Backend.Endpoint()
+	}
+
 	return restic.SetupOptions{
 		Provider:       provider,
 		Bucket:         bucket,
 		Path:           prefix,
-		Endpoint:       GetEndpoint(&repository.Spec.Backend),
+		Endpoint:       endpoint,
 		CacertFile:     extraOpt.CacertFile,
 		SecretDir:      extraOpt.SecretDir,
 		ScratchDir:     extraOpt.ScratchDir,
 		EnableCache:    extraOpt.EnableCache,
-		MaxConnections: GetMaxConnections(repository.Spec.Backend),
-		URL:            GetRestUrl(repository.Spec.Backend),
+		MaxConnections: repository.Spec.Backend.MaxConnections(),
+		URL:            restURL,
 	}, nil
 }

--- a/vendor/stash.appscode.dev/stash/pkg/util/sidecar.go
+++ b/vendor/stash.appscode.dev/stash/pkg/util/sidecar.go
@@ -99,7 +99,7 @@ func NewBackupSidecarContainer(bc *v1beta1_api.BackupConfiguration, backend *sto
 			"--backup-configuration=" + bc.Name,
 			"--secret-dir=" + StashSecretMountDir,
 			fmt.Sprintf("--enable-cache=%v", !bc.Spec.TempDir.DisableCaching),
-			fmt.Sprintf("--max-connections=%v", GetMaxConnections(*backend)),
+			fmt.Sprintf("--max-connections=%v", backend.MaxConnections()),
 			"--metrics-enabled=true",
 			"--pushgateway-url=" + PushgatewayURL(),
 			fmt.Sprintf("--enable-status-subresource=%v", apis.EnableStatusSubresource),

--- a/vendor/stash.appscode.dev/stash/pkg/util/util.go
+++ b/vendor/stash.appscode.dev/stash/pkg/util/util.go
@@ -23,7 +23,6 @@ import (
 	"stash.appscode.dev/stash/apis"
 	api_v1beta1 "stash.appscode.dev/stash/apis/stash/v1beta1"
 	cs "stash.appscode.dev/stash/client/clientset/versioned"
-	"stash.appscode.dev/stash/pkg/restic"
 )
 
 var (
@@ -161,13 +160,6 @@ func FixBackendPrefix(backend *store.Backend, autoPrefix string) *store.Backend 
 	return backend
 }
 
-func GetEndpoint(backend *store.Backend) string {
-	if backend.S3 != nil {
-		return backend.S3.Endpoint
-	}
-	return ""
-}
-
 // TODO: move to store
 func GetBucketAndPrefix(backend *store.Backend) (string, string, error) {
 	if backend.Local != nil {
@@ -184,46 +176,6 @@ func GetBucketAndPrefix(backend *store.Backend) (string, string, error) {
 		return "", "", nil
 	}
 	return "", "", errors.New("unknown backend type.")
-}
-
-// TODO: move to store
-func GetProvider(backend store.Backend) (string, error) {
-	if backend.Local != nil {
-		return restic.ProviderLocal, nil
-	} else if backend.S3 != nil {
-		return restic.ProviderS3, nil
-	} else if backend.GCS != nil {
-		return restic.ProviderGCS, nil
-	} else if backend.Azure != nil {
-		return restic.ProviderAzure, nil
-	} else if backend.Swift != nil {
-		return restic.ProviderSwift, nil
-	} else if backend.B2 != nil {
-		return restic.ProviderB2, nil
-	} else if backend.Rest != nil {
-		return restic.ProviderRest, nil
-	}
-	return "", errors.New("unknown provider.")
-}
-
-func GetRestUrl(backend store.Backend) string {
-	if backend.Rest != nil {
-		return backend.Rest.URL
-	}
-	return ""
-}
-
-// TODO: move to store
-// returns 0 if not specified
-func GetMaxConnections(backend store.Backend) int {
-	if backend.GCS != nil {
-		return backend.GCS.MaxConnections
-	} else if backend.Azure != nil {
-		return backend.Azure.MaxConnections
-	} else if backend.B2 != nil {
-		return backend.B2.MaxConnections
-	}
-	return 0
 }
 
 func ExtractDataFromRepositoryLabel(labels map[string]string) (data RepoLabelData, err error) {


### PR DESCRIPTION
Why?
Metrics will be handled by `update-status` function. It makes handling metrics uniform across all catalogs and we will be able to improve metrics easily.