### PR TITLE
fixed error in helm install; --name is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install PostgreSQL 11.2 backup or restore plugin for Stash as below.
 ```console
 helm repo add appscode https://charts.appscode.com/stable/
 helm repo update
-helm install appscode/stash-postgres --name=stash-postgres-11.2 --version=11.2
+helm install stash-postgres-11.2 appscode/stash-postgres --version=11.2
 ```
 
 To install catalog for all supported PostgreSQL versions, please visit [here](https://github.com/stashed/catalog).


### PR DESCRIPTION
helm install should be like:

```
helm install stash-postgres-10.2 appscode/stash-postgres --version=10.2 --namespace=kube-system
```

not
 
```
helm install appscode/stash-postgres --name=stash-postgres-10.2 --version=10.2 --namespace=kube-system
```