### PR TITLE
Prepare for release 11.9.0-v4

### DIFF
--- a/charts/stash-postgres/Chart.yaml
+++ b/charts/stash-postgres/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'stash-postgres - PostgreSQL database plugin for Stash by AppsCode'
 name: stash-postgres
-version: 11.9.0-v3
-appVersion: 11.9.0-v3
+version: 11.9.0-v4
+appVersion: 11.9.0-v4
 home: https://stash.run
 icon: https://cdn.appscode.com/images/products/stash/addons/postgres-stash-addon.png
 sources:

--- a/charts/stash-postgres/README.md
+++ b/charts/stash-postgres/README.md
@@ -7,7 +7,7 @@
 ```console
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm install stash-postgres-11.9.0-v3 appscode/stash-postgres -n kube-system --version=11.9.0-v3
+$ helm install stash-postgres-11.9.0-v4 appscode/stash-postgres -n kube-system --version=11.9.0-v4
 ```
 
 ## Introduction
@@ -20,10 +20,10 @@ This chart deploys necessary `Function` and `Task` definition to backup or resto
 
 ## Installing the Chart
 
-To install the chart with the release name `stash-postgres-11.9.0-v3`:
+To install the chart with the release name `stash-postgres-11.9.0-v4`:
 
 ```console
-$ helm install stash-postgres-11.9.0-v3 appscode/stash-postgres -n kube-system --version=11.9.0-v3
+$ helm install stash-postgres-11.9.0-v4 appscode/stash-postgres -n kube-system --version=11.9.0-v4
 ```
 
 The command deploys necessary `Function` and `Task` definition to backup or restore PostgreSQL 11.2 using Stash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -32,10 +32,10 @@ The command deploys necessary `Function` and `Task` definition to backup or rest
 
 ## Uninstalling the Chart
 
-To uninstall/delete the `stash-postgres-11.9.0-v3`:
+To uninstall/delete the `stash-postgres-11.9.0-v4`:
 
 ```console
-$ helm delete stash-postgres-11.9.0-v3 -n kube-system
+$ helm delete stash-postgres-11.9.0-v4 -n kube-system
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the `stash-postgres` ch
 | fullnameOverride | Overrides fullname template                                                                                                      | `""`             |
 | image.registry   | Docker registry used to pull Postgres addon image                                                                                | `stashed`        |
 | image.repository | Docker image used to backup/restore PosegreSQL database                                                                          | `stash-postgres` |
-| image.tag        | Tag of the image that is used to backup/restore PostgreSQL database. This is usually same as the database version it can backup. | `11.9.0-v3`      |
+| image.tag        | Tag of the image that is used to backup/restore PostgreSQL database. This is usually same as the database version it can backup. | `11.9.0-v4`      |
 | backup.cmd       | Postgres dump command, can either be: pg_dumpall  or pg_dump                                                                     | `"pg_dumpall"`   |
 | backup.args      | Arguments to pass to `backup.cmd` command during backup process                                                                  | `""`             |
 | restore.args     | Arguments to pass to `psql` command during restore process                                                                       | `""`             |
@@ -60,12 +60,12 @@ The following table lists the configurable parameters of the `stash-postgres` ch
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install stash-postgres-11.9.0-v3 appscode/stash-postgres -n kube-system --version=11.9.0-v3 --set image.registry=stashed
+$ helm install stash-postgres-11.9.0-v4 appscode/stash-postgres -n kube-system --version=11.9.0-v4 --set image.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install stash-postgres-11.9.0-v3 appscode/stash-postgres -n kube-system --version=11.9.0-v3 --values values.yaml
+$ helm install stash-postgres-11.9.0-v4 appscode/stash-postgres -n kube-system --version=11.9.0-v4 --values values.yaml
 ```

--- a/charts/stash-postgres/doc.yaml
+++ b/charts/stash-postgres/doc.yaml
@@ -10,11 +10,11 @@ repository:
   name: appscode
 chart:
   name: stash-postgres
-  version: 11.9.0-v3
+  version: 11.9.0-v4
   values: "-- generate from values file --"
   valuesExample: "-- generate from values file --"
 prerequisites:
 - Kubernetes 1.11+
 release:
-  name: stash-postgres-11.9.0-v3
+  name: stash-postgres-11.9.0-v4
   namespace: kube-system

--- a/charts/stash-postgres/values.yaml
+++ b/charts/stash-postgres/values.yaml
@@ -13,7 +13,7 @@ image:
   repository: stash-postgres
   # Tag of the image that is used to backup/restore PostgreSQL database.
   # This is usually same as the database version it can backup.
-  tag: 11.9.0-v3
+  tag: 11.9.0-v4
 backup:
   # Postgres dump command, can either be: pg_dumpall  or pg_dump
   cmd: "pg_dumpall"

--- a/docs/examples/backup/backupconfiguration.yaml
+++ b/docs/examples/backup/backupconfiguration.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   schedule: "*/5 * * * *"
   task:
-    name: postgres-backup-11.9.0-v3
+    name: postgres-backup-11.9.0-v4
   repository:
     name: gcs-repo
   target:

--- a/docs/examples/restore/restoresession.yaml
+++ b/docs/examples/restore/restoresession.yaml
@@ -7,7 +7,7 @@ metadata:
     kubedb.com/kind: Postgres # this label is mandatory if you are using KubeDB to deploy the database.
 spec:
   task:
-    name: postgres-restore-11.9.0-v3
+    name: postgres-restore-11.9.0-v4
   repository:
     name: gcs-repo
   target:

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	kmodules.xyz/custom-resources v0.0.0-20201124062543-bd8d35c21b0c
 	kmodules.xyz/offshoot-api v0.0.0-20201105074700-8675f5f686f2
 	sigs.k8s.io/yaml v1.2.0
-	stash.appscode.dev/apimachinery v0.11.7
+	stash.appscode.dev/apimachinery v0.11.8
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -964,8 +964,6 @@ kmodules.xyz/client-go v0.0.0-20201208053851-a1d7be95e006/go.mod h1:WXDwZBmvrcLg
 kmodules.xyz/constants v0.0.0-20200923054614-6b87dbbae4d6/go.mod h1:DbiFk1bJ1KEO94t1SlAn7tzc+Zz95rSXgyUKa2nzPmY=
 kmodules.xyz/crd-schema-fuzz v0.0.0-20200922204806-c1426cd7fcf4 h1:NWWv+Qju8xzHZT9hIk1+BbgQtIytNOoCU4g4vqUmh3M=
 kmodules.xyz/crd-schema-fuzz v0.0.0-20200922204806-c1426cd7fcf4/go.mod h1:WrO3fryNyFCgqqyWnwI89lnzWA7kN072Ehya7ELGfzE=
-kmodules.xyz/custom-resources v0.0.0-20201105075444-3c6af51b4f79 h1:BKPPUY/w0ac4R6g172zrejs+MLae2CHGqHCFpzrbRLc=
-kmodules.xyz/custom-resources v0.0.0-20201105075444-3c6af51b4f79/go.mod h1:/r3/eJ3LIfwGyBEVaobqUZRZGh7GJv5RJojj/bdD14Q=
 kmodules.xyz/custom-resources v0.0.0-20201124062543-bd8d35c21b0c h1:OIAnTI2yik4i1DSe23kO+89RMw/Eu6WUG/IQ++ivYNo=
 kmodules.xyz/custom-resources v0.0.0-20201124062543-bd8d35c21b0c/go.mod h1:/r3/eJ3LIfwGyBEVaobqUZRZGh7GJv5RJojj/bdD14Q=
 kmodules.xyz/objectstore-api v0.0.0-20201105133858-cbb2af88d50a h1:FJ8Fwn+BCalLuzkhjmyDf7Fuh19LBIEf/Fx/+xaYDB0=
@@ -994,6 +992,6 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=
-stash.appscode.dev/apimachinery v0.11.7 h1:NgAES2E1YWPAKJE7agHPOC9jGV2rFB/zW3XjRcSlyUo=
-stash.appscode.dev/apimachinery v0.11.7/go.mod h1:QnuI/VQTYxiT5ikxHqwOmqO96emPJPykbxfEp7pgjhk=
+stash.appscode.dev/apimachinery v0.11.8 h1:Po7gDpZqd+iQ8DR3zu1iJgIPQiFODPjiA6NIKhO2+7s=
+stash.appscode.dev/apimachinery v0.11.8/go.mod h1:s91NxOW9K/CLv9Cl9XVCzBLgdKqVcUOyc9VrYg0NNB0=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -885,7 +885,7 @@ sigs.k8s.io/structured-merge-diff/v3/typed
 sigs.k8s.io/structured-merge-diff/v3/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.11.7
+# stash.appscode.dev/apimachinery v0.11.8
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories
 stash.appscode.dev/apimachinery/apis/repositories/v1alpha1

--- a/vendor/stash.appscode.dev/apimachinery/apis/repositories/v1alpha1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/repositories/v1alpha1/openapi_generated.go
@@ -15937,7 +15937,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common
 						},
 					},
 				},
-				Required: []string{"key", "value", "stringValue"},
+				Required: []string{"key"},
 			},
 		},
 	}

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1alpha1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1alpha1/openapi_generated.go
@@ -15949,7 +15949,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common
 						},
 					},
 				},
-				Required: []string{"key", "value", "stringValue"},
+				Required: []string{"key"},
 			},
 		},
 	}

--- a/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/openapi_generated.go
+++ b/vendor/stash.appscode.dev/apimachinery/apis/stash/v1beta1/openapi_generated.go
@@ -15983,7 +15983,7 @@ func schema_custom_resources_apis_appcatalog_v1alpha1_AddKeyTransform(ref common
 						},
 					},
 				},
-				Required: []string{"key", "value", "stringValue"},
+				Required: []string{"key"},
 			},
 		},
 	}


### PR DESCRIPTION
ProductLine: Stash
Release: v2020.12.17
Release-tracker: https://github.com/stashed/CHANGELOG/pull/25
Signed-off-by: 1gtm <1gtm@appscode.com>