### PR TITLE
Prepare for release 10.14-v8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	kmodules.xyz/custom-resources v0.0.0-20210605111625-741fcb992541
 	kmodules.xyz/offshoot-api v0.0.0-20210504040651-7951e351f0f5
 	kmodules.xyz/prober v0.0.0-20210504215326-2e406706b970 // indirect
-	stash.appscode.dev/apimachinery v0.13.1-0.20210605201829-a382bbe2f22a
+	stash.appscode.dev/apimachinery v0.14.0
 )
 
 replace bitbucket.org/ww/goautoneg => gomodules.xyz/goautoneg v0.0.0-20120707110453-a547fc61f48d

--- a/go.sum
+++ b/go.sum
@@ -1019,5 +1019,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-stash.appscode.dev/apimachinery v0.13.1-0.20210605201829-a382bbe2f22a h1:VAyOdqztG50gKNAD2ByXuJAM29HpC09q4C+xe3hotag=
-stash.appscode.dev/apimachinery v0.13.1-0.20210605201829-a382bbe2f22a/go.mod h1:Y6fu0WnVwfiHlbNj100xhiQEoF+rG/kekmr7eQsx4mA=
+stash.appscode.dev/apimachinery v0.14.0 h1:7mTNxshQg90HA8zDMIA0oH9kohJxYE1iXpc/Dw42gQY=
+stash.appscode.dev/apimachinery v0.14.0/go.mod h1:Y6fu0WnVwfiHlbNj100xhiQEoF+rG/kekmr7eQsx4mA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -575,7 +575,7 @@ sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.13.1-0.20210605201829-a382bbe2f22a
+# stash.appscode.dev/apimachinery v0.14.0
 ## explicit
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2021.6.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/37
Signed-off-by: 1gtm <1gtm@appscode.com>