### PR TITLE
Prepare for release 12.4-v26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	kmodules.xyz/client-go v0.25.29
 	kmodules.xyz/custom-resources v0.25.2
 	kmodules.xyz/offshoot-api v0.25.4
-	stash.appscode.dev/apimachinery v0.30.1-0.20230814025143-fcb8a9106d3c
+	stash.appscode.dev/apimachinery v0.31.0
 )
 
 require github.com/onsi/gomega v1.20.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -896,5 +896,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.30.1-0.20230814025143-fcb8a9106d3c h1:/3plffjueo5ffL+XhHAtluJ9TfP+K9elbY1tyIxNeKY=
-stash.appscode.dev/apimachinery v0.30.1-0.20230814025143-fcb8a9106d3c/go.mod h1:IDbssRbYLSnMwZAQOGX4Vam+hl43FofP8BuXMLXVaPQ=
+stash.appscode.dev/apimachinery v0.31.0 h1:AXsuz/4K1ltW6oCVsqOS0EoYksVZTn60LXbK7V4IL90=
+stash.appscode.dev/apimachinery v0.31.0/go.mod h1:IDbssRbYLSnMwZAQOGX4Vam+hl43FofP8BuXMLXVaPQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -699,7 +699,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.30.1-0.20230814025143-fcb8a9106d3c
+# stash.appscode.dev/apimachinery v0.31.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.08.18
Release-tracker: https://github.com/stashed/CHANGELOG/pull/68
Signed-off-by: 1gtm <1gtm@appscode.com>