### PR TITLE
Prepare for release 11.9-v29

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,10 @@ require (
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
 	k8s.io/klog/v2 v2.110.1
-	kmodules.xyz/client-go v0.29.6
+	kmodules.xyz/client-go v0.29.7
 	kmodules.xyz/custom-resources v0.29.1
 	kmodules.xyz/offshoot-api v0.29.0
-	stash.appscode.dev/apimachinery v0.33.0-rc.0
+	stash.appscode.dev/apimachinery v0.33.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ k8s.io/utils v0.0.0-20231127182322-b307cd553661 h1:FepOBzJ0GXm8t0su67ln2wAZjbQ6R
 k8s.io/utils v0.0.0-20231127182322-b307cd553661/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kmodules.xyz/apiversion v0.2.0 h1:vAQYqZFm4xu4pbB1cAdHbFEPES6EQkcR4wc06xdTOWk=
 kmodules.xyz/apiversion v0.2.0/go.mod h1:oPX8g8LvlPdPX3Yc5YvCzJHQnw3YF/X4/jdW0b1am80=
-kmodules.xyz/client-go v0.29.6 h1:xTVq5LZvsPBUTLY7PORq7zveLOj/vpuTDvkpHWOk3RM=
-kmodules.xyz/client-go v0.29.6/go.mod h1:pHuzpwzEcDUIGjVVvwz9N8lY+6A7HXwvs2d7NtK7Hho=
+kmodules.xyz/client-go v0.29.7 h1:ax1QB4CA2olWU+DsLHwSiK5xvLlxOBpMnJWSu+gvRi8=
+kmodules.xyz/client-go v0.29.7/go.mod h1:uzg0eWRy+KvxAcXRRu2KNJlVgXXYbTujAgwsz/XR5EU=
 kmodules.xyz/custom-resources v0.29.1 h1:xiNylhs3ILRbcUhxxy306AOy9GMA4Mq7xFIptZKgal4=
 kmodules.xyz/custom-resources v0.29.1/go.mod h1:829zDY1EjaxPP52h1T73LZx/vgv8Pld9/uTT/ViZTc0=
 kmodules.xyz/objectstore-api v0.29.1 h1:uUsjf8KU0w4LYowSEOnl0AbHT3hsHIu1wNLHqGe1o6s=
@@ -564,5 +564,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+s
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
-stash.appscode.dev/apimachinery v0.33.0-rc.0 h1:yfLn3YYgfo12pTI8oOZBswkQpzFt4MzPaIaoZ2Nok64=
-stash.appscode.dev/apimachinery v0.33.0-rc.0/go.mod h1:M51wIqUONZ7cmx/h5W+Lp+/TlYAF8z7+kQJPsvtl7G4=
+stash.appscode.dev/apimachinery v0.33.0 h1:0HpdLsXTErZWTPl3xH1N2ev8SwLOwH20mTd8Y4Oy+yg=
+stash.appscode.dev/apimachinery v0.33.0/go.mod h1:3A7DVqgJfI7LbLAM5pBpJebd/mChJb86nmekm73TRGw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -694,7 +694,7 @@ k8s.io/utils/trace
 # kmodules.xyz/apiversion v0.2.0
 ## explicit; go 1.14
 kmodules.xyz/apiversion
-# kmodules.xyz/client-go v0.29.6
+# kmodules.xyz/client-go v0.29.7
 ## explicit; go 1.21.5
 kmodules.xyz/client-go
 kmodules.xyz/client-go/api/v1
@@ -790,7 +790,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# stash.appscode.dev/apimachinery v0.33.0-rc.0
+# stash.appscode.dev/apimachinery v0.33.0
 ## explicit; go 1.21.5
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2024.2.13
Release-tracker: https://github.com/stashed/CHANGELOG/pull/71
Signed-off-by: 1gtm <1gtm@appscode.com>